### PR TITLE
feat: Customize WebDriver config in custom launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ advanced tests to be executed in-browser.  If you don't need WebDriver to
 enable some test scenario in Karma, you can just use typical local browser
 launchers.
 
-Supports Chrome, Firefox, and Safari.
+Supports Chrome, Firefox, Edge, and Safari.
 
 
 ## Installation
@@ -36,7 +36,8 @@ already installed.
 // karma.conf.js
 module.exports = (config) => {
   config.set({
-    browsers: ['Chrome', 'Firefox', 'Safari']
+    plugins: ['karma-local-wd-launcher'],
+    browsers: ['Chrome', 'Firefox', 'Edge', 'Safari'],
   });
 };
 ```
@@ -45,4 +46,29 @@ You can give Karma's command-line interface a list of browsers, too:
 
 ```sh
 karma start --browsers Chrome Firefox Safari
+```
+
+There is a possibilty to create custom launcher based on existing ones, i.e. to
+pass additional configuration options to specific WebDriver.
+
+```js
+// karma.conf.js
+module.exports = (config) => {
+  config.set({
+    customLaunchers: {
+      'ChromeNoBackgroundSuspend': {
+        base: 'Chrome',
+        config: {
+          'goog:chromeOptions': {
+            args: [
+              '--disable-background-media-suspend',
+              '--disable-background-timer-throttling',
+              '--disable-backgrounding-occluded-windows',
+            ],
+          },
+        },
+      },
+    },
+  });
+};
 ```

--- a/index.js
+++ b/index.js
@@ -220,6 +220,18 @@ function generateSubclass(
   return subclass;
 }
 
+function generateSafariDriver(name, device = 'mac', simulator = false) {
+  const config = device == 'mac' ? {} : {
+    platformName: 'iOS',
+    'safari:deviceType': device,
+    'safari:useSimulator': simulator,
+  };
+  return generateSubclass('Safari', name,
+      '/usr/bin/safaridriver',
+      (port) => ['--port=' + port],
+      config);
+}
+
 const LocalWebDriverChrome = generateSubclass(
     'Chrome', 'Chrome',
     'chromedriver',
@@ -276,9 +288,19 @@ const LocalWebDriverFirefoxHeadless = generateSubclass(
       },
     });
 
-const LocalWebDriverSafari = generateSubclass(
-    'Safari', 'Safari',
-    '/usr/bin/safaridriver',
+const LocalWebDriverSafari = generateSafariDriver('Safari');
+
+const LocalWebDriverSafariIOS = generateSafariDriver('SafariIOS', 'iPhone');
+const LocalWebDriverSafariIOSSim =
+    generateSafariDriver('SafariIOSSim', 'iPhone', true);
+const LocalWebDriverSafariIPadOS =
+    generateSafariDriver('SafariIPadOS', 'iPad');
+const LocalWebDriverSafariIPadOSSim =
+    generateSafariDriver('SafariIPadOSSim', 'iPad', true);
+
+const LocalWebDriverSafariTP = generateSubclass(
+    'Safari Technology Preview', 'Safari Technology Preview',
+    '/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver',
     (port) => ['-p', port]);
 
 module.exports = {
@@ -293,4 +315,12 @@ module.exports = {
 // Safari is only supported on Mac.
 if (os.platform() == 'darwin') {
   module.exports['launcher:Safari'] = ['type', LocalWebDriverSafari];
+  module.exports['launcher:SafariIOS'] = ['type', LocalWebDriverSafariIOS];
+  module.exports['launcher:SafariIOSSim'] =
+      ['type', LocalWebDriverSafariIOSSim];
+  module.exports['launcher:SafariIPadOS'] =
+      ['type', LocalWebDriverSafariIPadOS];
+  module.exports['launcher:SafariIPadOSSim'] =
+      ['type', LocalWebDriverSafariIPadOSSim];
+  module.exports['launcher:SafariTP'] = ['type', LocalWebDriverSafariTP];
 }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const wd = require('wd');
+const _ = require('lodash');
 
 const {installWebDrivers} = require('webdriver-installer');
 
@@ -39,7 +40,7 @@ const PLATFORM_MAP = {
 //  - LAUNCHER_NAME: launcher name as presented to Karma
 //  - EXTRA_WEBDRIVER_SPECS: an object containing any extra WebDriver specs
 //  - getDriverArgs(port): take port as string, return driver command arguments
-const LocalWebDriverBase = function(baseBrowserDecorator, logger) {
+const LocalWebDriverBase = function(baseBrowserDecorator, args, logger) {
   baseBrowserDecorator(this);
 
   this.name = `${this.constructor.LAUNCHER_NAME} via WebDriver`;
@@ -61,6 +62,10 @@ const LocalWebDriverBase = function(baseBrowserDecorator, logger) {
 
   log.debug('config:', JSON.stringify(config));
 
+  const extraSpecs =
+      _.merge(this.constructor.EXTRA_WEBDRIVER_SPECS, args.config);
+  log.debug('extraSpecs:', extraSpecs);
+
   // These names ("browser" and "spec") are needed for compatibility with
   // karma-webdriver-launcher.
   this.browser = wd.remote(config);
@@ -70,7 +75,7 @@ const LocalWebDriverBase = function(baseBrowserDecorator, logger) {
     // This is necessary for safaridriver:
     allowW3C: true,
     // This allows extra configuration for headless variants:
-    ...this.constructor.EXTRA_WEBDRIVER_SPECS,
+    ...extraSpecs,
   };
 
   this.browser.on('status', (info) => {
@@ -192,8 +197,8 @@ function generateSubclass(
 
   // Karma will not use "new" to construct our class, so it can't be a true ES6
   // class.  Use the old function syntax instead.
-  const subclass = function(baseBrowserDecorator, logger) {
-    LocalWebDriverBase.call(this, baseBrowserDecorator, logger);
+  const subclass = function(baseBrowserDecorator, args, logger) {
+    LocalWebDriverBase.call(this, baseBrowserDecorator, args, logger);
   };
 
   // These are needed by our base class, LocalWebDriverBase.
@@ -215,7 +220,7 @@ function generateSubclass(
   };
 
   // This configures Karma's dependency injection system:
-  subclass.$inject = ['baseBrowserDecorator', 'logger'];
+  subclass.$inject = ['baseBrowserDecorator', 'args', 'logger'];
 
   return subclass;
 }

--- a/index.js
+++ b/index.js
@@ -279,7 +279,15 @@ const LocalWebDriverEdgeHeadless = generateSubclass(
 const LocalWebDriverFirefox = generateSubclass(
     'Firefox', 'Firefox',
     'geckodriver',
-    (port) => ['-p', port]);
+    (port) => ['-p', port],
+    {
+      'moz:firefoxOptions': {
+        prefs: {
+          'media.eme.enabled': true,
+          'media.gmp-manager.updateEnabled': true,
+        },
+      },
+    });
 
 const LocalWebDriverFirefoxHeadless = generateSubclass(
     'Firefox', 'FirefoxHeadless',
@@ -287,6 +295,10 @@ const LocalWebDriverFirefoxHeadless = generateSubclass(
     (port) => ['-p', port],
     {
       'moz:firefoxOptions': {
+        prefs: {
+          'media.eme.enabled': true,
+          'media.gmp-manager.updateEnabled': true,
+        },
         args: [
           '-headless',
         ],


### PR DESCRIPTION
Example of custom launcher with this PR:

```js
module.exports = function(config) {
  const firefoxOptions = {
    'moz:firefoxOptions': {
      prefs: {
        'media.eme.enabled': true,
        'media.gmp-manager.updateEnabled': true,
      },
    },
  };

  config.set({
    customLaunchers: {
      'FirefoxEME': {
        base: 'Firefox',
        config: firefoxOptions,
      },
      'FirefoxHeadlessEME': {
        base: 'FirefoxHeadless',
        config: firefoxOptions,
      },
    },
  });
};
```