### PR TITLE
fix: Fix hung launcher on shutdown of Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ const {installWebDrivers} = require('webdriver-installer');
 const DRIVER_CACHE = path.join(os.homedir(), '.webdriver-installer-cache');
 fs.mkdirSync(DRIVER_CACHE, {recursive: true});
 
+// Delay on startup to allow the WebDriver server to start.
+const WEBDRIVER_STARTUP_DELAY_SECONDS = 2;
+
 // If it takes longer than this to close our WebDriver session, give up.
 const CLOSE_WEBDRIVER_SESSION_TIMEOUT_SECONDS = 5;
 
@@ -94,7 +97,7 @@ const LocalWebDriverBase = function(baseBrowserDecorator, args, logger) {
   });
 
   this.on('start', async (url) => {
-    await delay(2 /* seconds */);
+    await delay(WEBDRIVER_STARTUP_DELAY_SECONDS);
 
     this.browser.init(this.spec, (error) => {
       if (error) {


### PR DESCRIPTION
In some cases (notably macOS Safari under GitHub Actions), a call to
forceKill() would be triggered during another call to forceKill().
This could cause the second Promise to go unresolved, leading to a
hang.  On GitHub, eventually, the workflow would be cancelled.

This fixes the nested calls to forceKill by making them both resolve
on the same event (the shutdown triggered by the first call).

This also adds a timeout for shutting down a WebDriver session.
Although this does not appear to be the root cause of the hang we
were experiencing in GitHub Actions workflows, it should be safer to
have this timeout.  If we can't stop a WebDriver session gracefully,
we will timeout after 5s and end the launcher anyway.

Closes #24