### PR TITLE
chore: Bump dep on async to fix npm audit results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,14 +214,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/archiver/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/archiver/node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -266,6 +258,14 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/asynckit": {
@@ -2358,14 +2358,6 @@
         "wd": "lib/bin.js"
       }
     },
-    "node_modules/wd/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/webdriver-installer": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.4.tgz",
@@ -2595,14 +2587,6 @@
         "zip-stream": "^2.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "glob": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -2710,6 +2694,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -4321,16 +4313,6 @@
         "q": "^1.5.1",
         "request": "2.88.0",
         "vargs": "^0.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
       }
     },
     "webdriver-installer": {


### PR DESCRIPTION
`npm audit` reported:

  async  <2.6.4
  Severity: high
  Prototype Pollution in async - https://github.com/advisories/GHSA-fwr7-v2mv-hh25
  fix available via `npm audit fix`
  node_modules/archiver/node_modules/async
  node_modules/wd/node_modules/async