### PR TITLE
fix: Fix clobbering of arguments in custom configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,6 @@ const LocalWebDriverChromeHeadless = generateSubclass(
       'goog:chromeOptions': {
         args: [
           '--headless',
-          '--no-sandbox',
           '--disable-gpu',
           '--disable-dev-shm-usage',
         ],

--- a/index.js
+++ b/index.js
@@ -68,8 +68,9 @@ const LocalWebDriverBase = function(baseBrowserDecorator, args, logger) {
 
   log.debug('config:', JSON.stringify(config));
 
-  const extraSpecs =
-      _.mergeWith(this.constructor.EXTRA_WEBDRIVER_SPECS, args.config,
+  const extraSpecs = _.mergeWith(
+      this.constructor.EXTRA_WEBDRIVER_SPECS,
+      args.config,
       (objValue, srcValue) => {
         if (Array.isArray(objValue)) {
           return objValue.concat(srcValue);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,12 @@ const LocalWebDriverBase = function(baseBrowserDecorator, args, logger) {
   log.debug('config:', JSON.stringify(config));
 
   const extraSpecs =
-      _.merge(this.constructor.EXTRA_WEBDRIVER_SPECS, args.config);
+      _.mergeWith(this.constructor.EXTRA_WEBDRIVER_SPECS, args.config,
+      (objValue, srcValue) => {
+        if (Array.isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+      });
   log.debug('extraSpecs:', extraSpecs);
 
   // These names ("browser" and "spec") are needed for compatibility with
@@ -273,6 +278,7 @@ const LocalWebDriverChromeHeadless = generateSubclass(
       'goog:chromeOptions': {
         args: [
           '--headless',
+          '--no-sandbox',
           '--disable-gpu',
           '--disable-dev-shm-usage',
         ],


### PR DESCRIPTION
Properly merge arrays when custom configuration is used, so i.e. ChromeHeadless now can be extended with additional args:

```js
customLaunchers: {
  'ChromeHeadlessNoSandbox': {
    base: 'ChromeHeadless',
    config: {
      'goog:chromeOptions': {
        args: [
          '--no-sandbox',
          // before we had to pass other args because merge wasn't working properly
          // '--headless',
          // '--disable-gpu',
          // '--disable-dev-shm-usage',
        ],
      },
    },
  },
},
```