### PR TITLE
fix: Fix ChromeHeadless in Docker

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,6 +273,7 @@ const LocalWebDriverChromeHeadless = generateSubclass(
       'goog:chromeOptions': {
         args: [
           '--headless',
+          '--no-sandbox',
           '--disable-gpu',
           '--disable-dev-shm-usage',
         ],


### PR DESCRIPTION
Currently ChromeHeadless cannot be run in the Docker environment due to lack of `--no-sandbox` argument. Trying to run ChromeHeadless within Docker ends with `DevToolsActivePort file doesn't exist` error. You can find more info here: https://bugs.chromium.org/p/chromedriver/issues/detail?id=2473

EDIT: of course this can be omitted by creating custom launcher, but I believe this can be so common issue it's better to tackle it by default. Additionally I'm planning to add running tests within Docker to shaka, so it'll easify process.
