### PR TITLE
fix: Work around msedgedriver 115+ bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21",
+        "node-which": "^1.0.0",
         "wd": "^1.14.0",
-        "webdriver-installer": "^1.1.8"
+        "webdriver-installer": "^1.1.9"
       },
       "peerDependencies": {
         "karma": "^6.2.0"
@@ -927,20 +928,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1499,6 +1486,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-which": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-which/-/node-which-1.0.0.tgz",
+      "integrity": "sha512-PVVbv6DyDc3VkTizcd/7Xchn3NDh+OUnQkrHxgumQ+2lwoWE36KuQClfAVjTwEh3T0jzb1WHrbgCol5HbBZqdQ==",
+      "deprecated": "please use 'which'"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2311,9 +2304,9 @@
       }
     },
     "node_modules/webdriver-installer": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.8.tgz",
-      "integrity": "sha512-Ptgz8VdhdzMPNDqVl7Z24n7vMIC+4wPM7C3HgU2Ikc70IXKqIUx6z+kooVs+ZKaUUvEhAhtxbs0kwqR5IERPvA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.9.tgz",
+      "integrity": "sha512-lWoCiOC9LvmGOgsTGCvu4opZxPBA76cPPbp93peSrO3djSLg5C6yDiyeWy+jN4uj3LHISZ5GTfjVOJmCE04OUQ==",
       "dependencies": {
         "node-fetch": "^2.6.7",
         "regedit": "^5.0.0",
@@ -3180,13 +3173,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true,
-      "peer": true
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3620,6 +3606,11 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-which": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-which/-/node-which-1.0.0.tgz",
+      "integrity": "sha512-PVVbv6DyDc3VkTizcd/7Xchn3NDh+OUnQkrHxgumQ+2lwoWE36KuQClfAVjTwEh3T0jzb1WHrbgCol5HbBZqdQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -4232,9 +4223,9 @@
       }
     },
     "webdriver-installer": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.8.tgz",
-      "integrity": "sha512-Ptgz8VdhdzMPNDqVl7Z24n7vMIC+4wPM7C3HgU2Ikc70IXKqIUx6z+kooVs+ZKaUUvEhAhtxbs0kwqR5IERPvA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.9.tgz",
+      "integrity": "sha512-lWoCiOC9LvmGOgsTGCvu4opZxPBA76cPPbp93peSrO3djSLg5C6yDiyeWy+jN4uj3LHISZ5GTfjVOJmCE04OUQ==",
       "requires": {
         "node-fetch": "^2.6.7",
         "regedit": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "author": "Joey Parrish <joeyparrish@google.com>",
   "dependencies": {
     "lodash": "^4.17.21",
+    "node-which": "^1.0.0",
     "wd": "^1.14.0",
-    "webdriver-installer": "^1.1.8"
+    "webdriver-installer": "^1.1.9"
   },
   "peerDependencies": {
     "karma": "^6.2.0"


### PR DESCRIPTION
Specify the explicit path to microsoft-edge if found, to work around https://github.com/MicrosoftEdge/EdgeWebDriver/issues/102#issuecomment-1710724173

This also incorporates
https://github.com/shaka-project/webdriver-installer/pull/35 to revert a previous workaround at that level.